### PR TITLE
Define unbound type variables

### DIFF
--- a/src/shards.erl
+++ b/src/shards.erl
@@ -1503,6 +1503,8 @@ update_element(Tab, Key, ElementSpec) ->
       Tab         :: tab(),
       Key         :: term(),
       ElementSpec :: {Pos, Value} | [{Pos, Value}],
+      Pos         :: pos_integer(),
+      Value       :: term(),
       Meta        :: shards_meta:t().
 update_element(Tab, Key, ElementSpec, Meta) ->
   PartTid = shards_partition:tid(Tab, Key, Meta),


### PR DESCRIPTION
Shards fails to compile with OTP26-rc2 because of following error: 

```erlang
===> Compiling src/shards.erl failed
src/shards.erl:1505:23: type variable 'Pos' is only used once (is unbound)
src/shards.erl:1505:28: type variable 'Value' is only used once (is unbound)
```

This PR adds type definitions to these variables.